### PR TITLE
Error handling for dispersion process.

### DIFF
--- a/lib/stp/orden_pago.rb
+++ b/lib/stp/orden_pago.rb
@@ -108,7 +108,7 @@ module Stp
         body = body[:return]
         id = body[:id].to_i
 
-        raise Error.new(body[:descripcion_error], response) unless id > 0
+        raise Error.new("#{body[:id]}_#{body[:descripcion_error]}", response) unless id > 0 && id.to_s.length > 3
 
         return id
       rescue NoMethodError => e

--- a/lib/stp/orden_pago.rb
+++ b/lib/stp/orden_pago.rb
@@ -108,7 +108,7 @@ module Stp
         body = body[:return]
         id = body[:id].to_i
 
-        raise Error.new("#{body[:id]}_#{body[:descripcion_error]}", response) unless id > 0 && id.to_s.length > 3
+        raise Error.new("#{body[:id]}_#{body[:descripcion_error]}", response) unless id.positive? && id.to_s.length > 3
 
         return id
       rescue NoMethodError => e


### PR DESCRIPTION
The error is now considering length of the error code and now is being returned within the error message for further processing. 